### PR TITLE
simplejson works better on python 2.6.6 than json

### DIFF
--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -16,7 +16,7 @@ LICENSE: MIT
 --------
 '''
 
-import json
+import simplejson
 import ordereddict
 
 class JSON:
@@ -40,9 +40,9 @@ class JSON:
 		if 'json' in args:
 			self.json_input = args['json']
 			try:
-				json.loads(self.json_input)
+				simplejson.loads(self.json_input)
 			except:
-				self.json_input = json.dumps(self.json_input)
+				self.json_input = simplejson.dumps(self.json_input)
 		else:
 			raise Exception('Can\'t convert NULL!')
 


### PR DESCRIPTION
Running on python 2.6.6, I received the following error:

  File "/usr/lib/python2.6/site-packages/json2html/jsonconv.py", line 50, in convert
    ordered_json = json.loads(self.json_input, object_pairs_hook=ordereddict.OrderedDict)
  File "/usr/lib64/python2.6/json/__init__.py", line 318, in loads
    return cls(encoding=encoding, **kw).decode(s)
TypeError: __init__() got an unexpected keyword argument 'object_pairs_hook'


By changing the json library to the simplejson library, I was able to successfully run the code without errors :)