### PR TITLE
Fixed issue where certain values would not output

### DIFF
--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -93,6 +93,8 @@ class JSON:
 			'''
 			Check for each value corresponding to its key and return accordingly
 			'''
+			if(not isinstance(entry,list) and not isinstance(entry,dict)):
+				return str(entry)
 			if(isinstance(entry,unicode)):
 				return unicode(entry)
 			if(isinstance(entry,int) or isinstance(entry,float)):


### PR DESCRIPTION
When running the code with various json files, certain data would not output into the table at all. I figured out that the two if statements that check if the data is unicode or int/float is not enough. For some reason, some data is not an instance of any of these and therefore will never output. So, unless the entry is a list or a dict, I returned the string version of entry. It works perfectly!
