### PR TITLE
remove non-ascii character in README.md for python 3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ Tests
 Contributors
 ------------
 
-1. Michel Müller: `@muellermichel <https://github.com/muellermichel>`_
+1. Michel Mueller: `@muellermichel <https://github.com/muellermichel>`_
 	* patch `#2 <https://github.com/softvar/json2html/pull/2>`_
 	* Added support for clubbing Array of Objects with same keys, more readable format.
 	* Added support for adding custom `table_attributes`.

--- a/json2html/__init__.py
+++ b/json2html/__init__.py
@@ -3,7 +3,7 @@ python wrapper for JSON to HTML-Table convertor
 (c) 2013 Varun Malhotra. MIT License
 '''
 
-from jsonconv import *
+from .jsonconv import *
 
 __author__ = 'Varun Malhotra'
 __version__ = '1.0.1'

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -139,7 +139,8 @@ class Json2Html:
         convertedOutput = convertedOutput + table_init_markup
 
         try:
-            for (k, v) in iteritems(inputtedJson):
+            for k in sorted(inputtedJson):
+                v = inputtedJson[k]
                 convertedOutput = convertedOutput + '<tr>'
                 convertedOutput = convertedOutput + '<th>' + markup(k) + '</th>'
 

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -109,8 +109,12 @@ class Json2Html:
                 Check for each value corresponding to its key
                 and return accordingly
             '''
-            if (isinstance(entry, unicode)):
-                return unicode(entry)
+            if (sys.version_info[:2] < (3, 0)):
+                if (isinstance(entry, unicode)):
+                    return unicode(entry)
+            else:
+                if (isinstance(entry, str)):
+                    return entry
             if (isinstance(entry, int) or isinstance(entry, float)):
                 return str(entry)
             if (isinstance(entry, list) == True) and len(entry) == 0:

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -17,6 +17,7 @@ LICENSE: MIT
 '''
 
 import sys
+from six import iteritems
 
 if (sys.version_info[:2] < (2, 7)):
     import simplejson as json

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -158,8 +158,8 @@ class Json2Html:
                 convertedOutput = convertedOutput + '</tr>'
             convertedOutput = convertedOutput + '</table>'
 
-        except:
-            raise Exception('Not a valid JSON list')
+        except Exception as e:
+            raise Exception('Could not process JSON list:' + e)
         return convertedOutput
 
 json2html = Json2Html()

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -135,7 +135,7 @@ class Json2Html:
         convertedOutput = convertedOutput + table_init_markup
 
         try:
-            for (k, v) in inputtedJson.iteritems():
+            for (k, v) in iteritems(inputtedJson):
                 convertedOutput = convertedOutput + '<tr>'
                 convertedOutput = convertedOutput + '<th>' + markup(k) + '</th>'
 
@@ -160,7 +160,7 @@ class Json2Html:
             convertedOutput = convertedOutput + '</table>'
 
         except Exception as e:
-            raise Exception('Could not process JSON list:' + e)
+            raise Exception('Could not process JSON list:' + str(e))
         return convertedOutput
 
 json2html = Json2Html()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version_info[:2] < (2,7):
 setup(
     name = 'json2html',
     packages = ['json2html'],
-    version = '1.0.1',
+    version = '1.0.1rh',
     install_requires=required,
     description = 'JSON to HTML Table Representation',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
setup relies on pure ascii chars to obtain long_description:

```
long_description=open('README.rst').read()
```

This failed with python3. 
