### PR TITLE
Compatibility with non-JSON objects, html encode feature, better empty object behaviour, cleaned up the code some more

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,14 +42,14 @@ Live Demo
 List of valid arguments
 -----------------------
 
-``json2html.convert`` - The module's ``convert`` method accepts three different types of arguments being passed.
+``json2html.convert`` - The module's ``convert`` method accepts the following arguments:
 
 ===================== ================
 Argument              Description
 --------------------- ----------------
 `json`                a valid JSON
 --------------------- ----------------
-`table_attributes`    `id="info-table"`/`class="bootstrap-class"`/`data-*` attributes can be applied to the generated table
+`table_attributes`    e.g. pass `id="info-table"` or `class="bootstrap-class"`/`data-*` to apply these attributes to the generated table
 --------------------- ----------------
 `clubbing`            turn on[default]/off clubbing of list with same keys of a dict / Array of objects with same key
 --------------------- ----------------

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,9 @@ Argument              Description
 --------------------- ----------------
 `table_attributes`    `id="info-table"`/`class="bootstrap-class"`/`data-*` attributes can be applied to the generated table
 --------------------- ----------------
-`clubbing`            turn clubbing of list with same keys of a dict / Array of objects with same key
+`clubbing`            turn on[default]/off clubbing of list with same keys of a dict / Array of objects with same key
+--------------------- ----------------
+`encode`              turn on/off[default] encoding of result to escaped html, compatible with any browser
 ===================== ================
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,8 @@ Contributors
 	* Now supports JSON Lists (at top level), including clubbing.
 	* Now supports empty inputs and positional arguments for convert.
 	* Python 3 support ; Added integration tests for Python 2.6, 3.4 and 3.5 such that support doesn't break.
+	* Can now also do the proper encoding for you (disabled by default to not break backwards compatibility).
+	* Can now handle non-JSON objects on a best-effort principle.
 
 2. Daniel Lekic: `@lekic <https://github.com/lekic>`_
 	* `Patch #17 <https://github.com/softvar/json2html/pull/17>`_

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ List of valid arguments
 ===================== ================
 Argument              Description
 --------------------- ----------------
-`json`                a valid JSON
+`json`                a valid JSON; This can either be a string in valid JSON format or a python object that is either dict-like or list-like at the top level.
 --------------------- ----------------
 `table_attributes`    e.g. pass `id="info-table"` or `class="bootstrap-class"`/`data-*` to apply these attributes to the generated table
 --------------------- ----------------

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -59,8 +59,8 @@ class Json2Html:
             It tries to come up with column headers for your input
         """
         if not json_input \
-        or not hasattr(json_input[0], 'keys') \
-        or not hasattr(json_input[0], '__getitem__'):
+        or not hasattr(json_input, '__getitem__') \
+        or not hasattr(json_input[0], 'keys'):
             return None
         column_headers = json_input[0].keys()
         for entry in json_input:

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -82,7 +82,7 @@ class Json2Html:
             of funky objects to json2html that *behave* like dicts and lists and other 
             basic JSON types.
         """
-        if type(json_input) in text_types + [int, float]:
+        if type(json_input) in text_types:
             return text(json_input)
         if hasattr(json_input, 'items'):
             return self.convert_object(json_input)

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -138,12 +138,6 @@ class Json2Html:
         converted_output += '</li><li>'.join([self.convert_json_node(child) for child in list_input])
         converted_output += '</li></ul>'
         return converted_output
-        
-    def convert_cell_content(self, cell_input):
-        """
-            Wrap content in <td> markup
-        """
-        return '<td>' + self.convert_json_node(cell_input) + '</td>'
 
     def convert_object(self, json_input):
         """
@@ -154,9 +148,9 @@ class Json2Html:
             return "" #avoid empty tables
         converted_output = self.table_init_markup + "<tr>"
         converted_output += "</tr><tr>".join([
-            "<th>%s</th>%s" %(
+            "<th>%s</th><td>%s</td>" %(
                 self.convert_json_node(k),
-                self.convert_cell_content(self.convert_json_node(v)),
+                self.convert_json_node(v)
             )
             for k, v in json_input.items()
         ])

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -65,7 +65,7 @@ class Json2Html:
         column_headers = json_input[0].keys()
         for entry in json_input:
             if not hasattr(entry, 'keys') \
-            or not hasattr(entry, '__getitem__') \
+            or not hasattr(entry, '__iter__') \
             or len(entry.keys()) != len(column_headers):
                 return None
             for header in column_headers:
@@ -85,7 +85,7 @@ class Json2Html:
             return text(json_input)
         if hasattr(json_input, 'items'):
             return self.convert_object(json_input)
-        if hasattr(json_input, '__iter__'):
+        if hasattr(json_input, '__iter__') and hasattr(json_input, '__getitem__'):
             return self.convert_list(json_input)
         return text(json_input)
 

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -34,29 +34,65 @@ else:
     text_types = [str]
 
 class Json2Html:
-    def convert(self, json="", table_attributes='border="1"', clubbing=True):
+    def convert(self, json="", table_attributes='border="1"', clubbing=True, encode=False):
         """
             Convert JSON to HTML Table format
         """
-
         # table attributes such as class, id, data-attr-*, etc.
         # eg: table_attributes = 'class = "table table-bordered sortable"'
         self.table_init_markup = "<table %s>" % table_attributes
         self.clubbing = clubbing
-
         if not json:
             json_input = {}
         elif type(json) in text_types:
             json_input = json_parser.loads(json, object_pairs_hook=OrderedDict)
         else:
             json_input = json
-
-        if isinstance(json_input, list):
-            return self.convert_list(json_input)
-        return self.convert_json(json_input)
+        converted = self.convert_json_node(json_input)
+        if encode:
+            return converted.encode('ascii', 'xmlcharrefreplace')
+        return converted
 
     def column_headers_from_list_of_dicts(self, json_input):
         """
+            This method is required to implement clubbing. 
+            It tries to come up with column headers for your input
+        """
+        if not json_input \
+        or not hasattr(json_input[0], 'keys') \
+        or not hasattr(json_input[0], '__getitem__'):
+            return None
+        column_headers = json_input[0].keys()
+        for entry in json_input:
+            if not hasattr(entry, 'keys') \
+            or not hasattr(entry, '__getitem__') \
+            or len(entry.keys()) != len(column_headers):
+                return None
+            for header in column_headers:
+                if header not in entry:
+                    return None
+        return column_headers
+
+    def convert_json_node(self, json_input):
+        """
+            Dispatch JSON input according to the outermost type and process it
+            to generate the super awesome HTML format.
+            We try to adhere to duck typing such that users can just pass all kinds 
+            of funky objects to json2html that *behave* like dicts and lists and other 
+            basic JSON types.
+        """
+        if type(json_input) in text_types + [int, float]:
+            return text(json_input)
+        if hasattr(json_input, 'items'):
+            return self.convert_object(json_input)
+        if hasattr(json_input, '__iter__'):
+            return self.convert_list(json_input)
+        return text(json_input)
+
+    def convert_list(self, list_input):
+        """
+            Iterate over the JSON list and process it
+            to generate either an HTML table or a HTML list, depending on what's inside.
             If suppose some key has array of objects and all the keys are same,
             instead of creating a new row for each such entry,
             club such values, thus it makes more sense and more readable table.
@@ -79,44 +115,8 @@ class Json2Html:
 
             @contributed by: @muellermichel
         """
-        if not json_input or not isinstance(json_input[0], dict):
-            return None
-
-        column_headers = json_input[0].keys()
-        for entry in json_input:
-            if not isinstance(entry, dict) or (len(entry.keys()) != len(column_headers)):
-                return None
-            for header in column_headers:
-                if header not in entry:
-                    return None
-        return column_headers
-
-    def convert_json(self, json_input):
-        """
-            Iterate over the JSON input and process it
-            to generate the super awesome HTML format
-        """
-        if type(json_input) in text_types + [int, float]:
-            return text(json_input)
-        if isinstance(json_input, list) and len(json_input) == 0:
-            return ''
-        if isinstance(json_input, list):
-            list_markup = '<ul><li>'
-            list_markup += '</li><li>'.join([self.convert_json(child) for child in json_input])
-            list_markup += '</li></ul>'
-            return list_markup
-        if isinstance(json_input, dict):
-            return self.convert_object(json_input)
-
-        # safety: don't do recursion over anything that we don't know about
-        # - iteritems() will most probably fail
-        return ''
-
-    def convert_list(self, list_input):
-        """
-            Iterate over the JSON list and process it
-            to generate either an HTML table or a HTML list, depending on what's inside.
-        """
+        if not list_input:
+            return ""
         converted_output = ""
         column_headers = None
         if self.clubbing:
@@ -126,35 +126,41 @@ class Json2Html:
             converted_output += '<tr><th>' + '</th><th>'.join(column_headers) + '</th></tr>'
             for list_entry in list_input:
                 converted_output += '<tr><td>'
-                converted_output += '</td><td>'.join([self.convert_json(list_entry[column_header]) for column_header in
+                converted_output += '</td><td>'.join([self.convert_json_node(list_entry[column_header]) for column_header in
                                                      column_headers])
                 converted_output += '</td></tr>'
             converted_output += '</table>'
-        else:
-            converted_output += self.convert_json(list_input)
-        return converted_output
+            return converted_output
 
+        #so you don't want or need clubbing eh? This makes @muellermichel very sad... ;(
+        #alright, let's fall back to a basic list here...
+        converted_output = '<ul><li>'
+        converted_output += '</li><li>'.join([self.convert_json_node(child) for child in list_input])
+        converted_output += '</li></ul>'
+        return converted_output
+        
     def convert_cell_content(self, cell_input):
         """
             Wrap content in <td> markup
         """
-        return '<td>' + self.convert_json(cell_input) + '</td>'
+        return '<td>' + self.convert_json_node(cell_input) + '</td>'
 
     def convert_object(self, json_input):
         """
             Iterate over the JSON object and process it
             to generate the super awesome HTML Table format
         """
-        converted_output = self.table_init_markup
-        for k, v in json_input.items():
-            converted_output += '<tr><th>' + self.convert_json(k) + '</th>'
-            if v is None:
-                v = text("")
-            if isinstance(v, list):
-                converted_output += self.convert_cell_content(self.convert_list(v)) + "</tr>"
-            else:
-                converted_output += self.convert_cell_content(v) + "</tr>"
-        converted_output += '</table>'
+        if not json_input:
+            return "" #avoid empty tables
+        converted_output = self.table_init_markup + "<tr>"
+        converted_output += "</tr><tr>".join([
+            "<th>%s</th>%s" %(
+                self.convert_json_node(k),
+                self.convert_cell_content(self.convert_json_node(v)),
+            )
+            for k, v in json_input.items()
+        ])
+        converted_output += '</tr></table>'
         return converted_output
 
 json2html = Json2Html()

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -42,6 +42,7 @@ class Json2Html:
         # eg: table_attributes = 'class = "table table-bordered sortable"'
         self.table_init_markup = "<table %s>" % table_attributes
         self.clubbing = clubbing
+        json_input = None
         if not json:
             json_input = {}
         elif type(json) in text_types:

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -176,6 +176,18 @@ class TestJson2Html(unittest.TestCase):
             u'<ul><li><ul><li>1</li><li>2</li></ul></li><li>blübi</li></ul>'
         )
 
+    def test_bool(self):
+        self.assertEqual(
+            json2html.convert(True),
+            u'True'
+        )
+
+    def test_none(self):
+        self.assertEqual(
+            json2html.convert(None),
+            u''
+        )
+
     def test_all(self):
         for test_definition in self.test_json:
             _json = test_definition['json']

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os, sys, re
 
 lib_path = os.path.abspath(os.path.join('..'))
@@ -37,15 +38,15 @@ class TestJson2Html(unittest.TestCase):
         pass
 
     def test_empty_json(self, *args, **kwargs):
-        self.assertTrue(
+        self.assertEqual(
             json2html.convert(json = ""),
             ""
         )
-        self.assertTrue(
+        self.assertEqual(
             json2html.convert(json = []),
             ""
         )
-        self.assertTrue(
+        self.assertEqual(
             json2html.convert(json = {}),
             ""
         )
@@ -55,8 +56,47 @@ class TestJson2Html(unittest.TestCase):
             _json = "{'name'}"
             with self.assertRaises(ValueError) as context:
                 json2html.convert(json = _json)
-
             self.assertIn('Expecting property name', str(context.exception))
+
+    def test_funky_objects(self):
+        class objecty_class1(object):
+            pass
+        class objecty_class2(object):
+            def __repr__(self):
+                return u"blübidö"
+        class objecty_class3:
+            pass
+        class objecty_class4:
+            def __repr__(self):
+                return u"blübidöbidü"
+        objecty_the_funky_object1 = objecty_class1()
+        objecty_the_funky_object2 = objecty_class2()
+        objecty_the_funky_object3 = objecty_class3()
+        objecty_the_funky_object4 = objecty_class4()
+        funky_non_json_object = (
+            {"blib":(u"blüb", u"ـث‎"), u"ـث‎":1E-3},
+            "blub",
+            {
+                1: objecty_the_funky_object1,
+                2: objecty_the_funky_object2,
+                3: objecty_the_funky_object3,
+                4: objecty_the_funky_object4,
+            },
+            tuple([
+                objecty_the_funky_object1,
+                objecty_the_funky_object2,
+                objecty_the_funky_object3,
+                objecty_the_funky_object4
+            ])
+        )
+        converted = json2html.convert(funky_non_json_object)
+        self.assertTrue(u"ـث‎" in converted)
+        self.assertTrue(u"blüb" in converted)
+        self.assertTrue(u"blübidö" in converted)
+        self.assertTrue(u"blübidöbidü" in converted)
+        self.assertTrue(u"blübidöbidü" in converted)
+        self.assertTrue(u"objecty_class1" in converted)
+        self.assertTrue(u"objecty_class3" in converted)
 
     def test_all(self):
         for test_definition in self.test_json:
@@ -64,13 +104,13 @@ class TestJson2Html(unittest.TestCase):
             _clubbing = "no_clubbing" not in test_definition['filename']
             print("testing %s" %(test_definition['filename']))
             self.assertEqual(
-                json2html.convert(json = _json, clubbing=_clubbing),
-                test_definition['output']
+                json2html.convert(json = _json, clubbing=_clubbing, encode=True),
+                test_definition['output'].encode('ascii', 'xmlcharrefreplace')
             )
             #testing whether we can call convert with a positional args instead of keyword arg
             self.assertEqual(
-                json2html.convert(_json, clubbing=_clubbing),
-                test_definition['output']
+                json2html.convert(_json, clubbing=_clubbing, encode=True),
+                test_definition['output'].encode('ascii', 'xmlcharrefreplace')
             )
 
 


### PR DESCRIPTION
Hey Varun. 

Sorry to bother you again, but I just couldn't leave it be, I still wasn't quite happy ;).

If you look at the new test case, I added compatibility to previously unhandled objects, plus I made it aware of anything dict-like and list-like, instead of just handling dicts and lists. This allows funky things like passing tuples and objects. Plus I tested unicode and decided to add an encode-feature such that users don't have to care and can just return the result in their webserver response function, and all unicode characters just work. To use this, you need to pass `encode=True`, I decided against making it default because it would break compatibility. 

This I think takes care of the needs stated in the other PR that's still open.