### PR TITLE
Add license to distribution package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENSE.txt


### PR DESCRIPTION
Needed for other packaging infrastructures (and good just in general), e.g. conda.