### PR TITLE
Add support for Python 3.6-3.7, drop support for 2.6 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
+  - "3.7"
 
 # command to run tests
 script: cd test/ && python run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8-dev"
 
 # command to run tests
 script: cd test/ && python run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.4"
   - "3.5"
-
-# command to install dependencies
-install: "pip install ordereddict simplejson"
 
 # command to run tests
 script: cd test/ && python run_tests.py

--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ Tests
 	cd test/
 	python run_tests.py
 
-Tested with Python 2.6, 2.7 3.4, and 3.5.
+Tested with Python 2.7 and 3.5.
 
 Contributors
 ------------

--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ Tests
 	cd test/
 	python run_tests.py
 
-Tested with Python 2.7 and 3.5.
+Tested with Python 2.7 and 3.5+.
 
 Contributors
 ------------

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -19,12 +19,8 @@ LICENSE: MIT
 
 import sys
 
-if sys.version_info[:2] < (2, 7):
-    from ordereddict import OrderedDict
-    import simplejson as json_parser
-else:
-    from collections import OrderedDict
-    import json as json_parser
+from collections import OrderedDict
+import json as json_parser
 
 if sys.version_info[:2] < (3, 0):
     from cgi import escape as html_escape

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,13 @@ setup(
     keywords = ['json', 'HTML', 'Table'],
     license = 'MIT',
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
-    classifiers = (
-    ),
+    classifiers = [
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,10 @@
-import sys
 from setuptools import setup
 
-required = []
-
-
-if sys.version_info[:2] < (2,7):
-    required.append('simplejson')
-    required.append('ordereddict')
 
 setup(
     name = 'json2html',
     packages = ['json2html'],
     version = '1.3.0',
-    install_requires=required,
     description = 'JSON to HTML Table Representation',
     long_description=open('README.rst').read(),
     author = 'Varun Malhotra',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     download_url = 'https://github.com/softvar/json2html/tarball/1.3.0',
     keywords = ['json', 'HTML', 'Table'],
     license = 'MIT',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers = (
     ),
 )

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -52,11 +52,10 @@ class TestJson2Html(unittest.TestCase):
         )
 
     def test_invalid_json_exception(self, *args, **kwargs):
-        if sys.version_info[:2] >= (2, 7): #Python below 2.7 doesn't have assertRaises, ommitting these tests
-            _json = "{'name'}"
-            with self.assertRaises(ValueError) as context:
-                json2html.convert(json = _json)
-            self.assertIn('Expecting property name', str(context.exception))
+        _json = "{'name'}"
+        with self.assertRaises(ValueError) as context:
+            json2html.convert(json = _json)
+        self.assertIn('Expecting property name', str(context.exception))
 
     def test_funky_objects(self):
         class objecty_class1(object):


### PR DESCRIPTION
Fixes #42. 

Python 2.6 and 3.4 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

They're also little used. Here's the pip installs for json2html from PyPI for August 2019:

| category | percent | downloads |
|----------|--------:|----------:|
|      3.7 |  32.54% |    12,014 |
|      2.7 |  28.25% |    10,431 |
|      3.6 |  26.78% |     9,889 |
|      3.5 |   8.79% |     3,246 |
| null     |   2.89% |     1,067 |
|      3.4 |   0.67% |       246 |
|      2.6 |   0.07% |        26 |
|      3.8 |   0.00% |         1 |
| Total    |         |    36,920 |

Source: `pip install -U pypistats && pypistats python_minor json2html --last-month`
 
---

Also adds support for Python 3.6 and 3.7, adds `python_requires` to help the right version of this package for the user's Python, and some Trove classifiers.

And also tests on Python 3.8, to help test 3.8 itself, plus ensure this library works on it.
