### PR TITLE
Make examples py3 compatible

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -11,4 +11,4 @@ _json = {
 }
 
 output = json2html.convert(json = _json)
-print output
+print (output)

--- a/examples/clubbing_keys_of_array_of_objects.py
+++ b/examples/clubbing_keys_of_array_of_objects.py
@@ -13,4 +13,4 @@ _json = {
 }
 
 output = json2html.convert(json = _json)
-print output
+print (output)

--- a/examples/deep_nesting.py
+++ b/examples/deep_nesting.py
@@ -29,4 +29,4 @@ _json = {
 }
 
 output = json2html.convert(json = _json)
-print output
+print (output)

--- a/examples/setting_custom_attrs.py
+++ b/examples/setting_custom_attrs.py
@@ -12,4 +12,4 @@ _json = {
 }
 
 output = json2html.convert(json = _json, table_attributes="class=\"table table-bordered table-hover\"")
-print output
+print (output)


### PR DESCRIPTION
Fix print statements in all examples to make them py3
compatible.