### PR TITLE
Option to add HTML line breaks to multiline text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev"
+  - "3.8"
+  - "3.9"
+  - "3.10-dev"
 
 # command to run tests
 script: cd test/ && python run_tests.py

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,8 @@ Argument              Description
 `encode`              turn on/off[default] encoding of result to escaped html, compatible with any browser
 --------------------- ----------------
 `escape`              turn on[default]/off escaping of html tags in text nodes (prevents XSS attacks in case you pass untrusted data to json2html)
+--------------------- ----------------
+`multiline`           turn on/off[default] using HTML line breaks in multiline text nodes
 ===================== ================
 
 Installation

--- a/json2html/jsonconv.py
+++ b/json2html/jsonconv.py
@@ -33,7 +33,7 @@ else:
 
 
 class Json2Html:
-    def convert(self, json="", table_attributes='border="1"', clubbing=True, encode=False, escape=True):
+    def convert(self, json="", table_attributes='border="1"', clubbing=True, encode=False, escape=True, multiline=False):
         """
             Convert JSON to HTML Table format
         """
@@ -42,6 +42,7 @@ class Json2Html:
         self.table_init_markup = "<table %s>" % table_attributes
         self.clubbing = clubbing
         self.escape = escape
+        self.multiline = multiline
         json_input = None
         if not json:
             json_input = {}
@@ -91,10 +92,12 @@ class Json2Html:
             basic JSON types.
         """
         if type(json_input) in text_types:
+            html_output = text(json_input)
             if self.escape:
-                return html_escape(text(json_input))
-            else:
-                return text(json_input)
+                html_output = html_escape(html_output)
+            if self.multiline:
+                html_output = html_output.replace("\n", "<br/>")
+            return html_output
         if hasattr(json_input, 'items'):
             return self.convert_object(json_input)
         if hasattr(json_input, '__iter__') and hasattr(json_input, '__getitem__'):

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -197,6 +197,16 @@ class TestJson2Html(unittest.TestCase):
             u"<script></script>"
         )
 
+    def test_multiline(self):
+        self.assertEqual(
+            json2html.convert("a\nb"),
+            u"a\nb"
+        )
+        self.assertEqual(
+            json2html.convert("a\nb", multiline=True),
+            u"a<br/>b"
+        )
+
     def test_all(self):
         for test_definition in self.test_json:
             _json = test_definition['json']


### PR DESCRIPTION
This change adds a 'multiline' argument to `json2html.convert`. When enabled, line breaks are replaced with HTML `<br/>` tags, preserving them in the rendered HTML. This argument is `False` by default, retaining backwards-compatibility,

This is similar in intent to #19, but uses explicit line breaks rather than `<pre>` tags, which can lead to a bunch of style changes like monospace font usage.
